### PR TITLE
Use pathlib to concatenate paths inpdendent of OS

### DIFF
--- a/ERA5_modellevel.py
+++ b/ERA5_modellevel.py
@@ -11,12 +11,13 @@ import pandas as pd
 import csv
 import datetime
 import numpy as np
+from pathlib import Path
 
 #PATHS AND SETTINGS FOR ONSHORE AWE
-inputpath= 'YOUR DIRECTORY TO THIS FOLDER'
-outputpath= inputpath + '\\capacityfactors\\'
+inputpath= Path(__file__).parent
+outputpath= inputpath / 'capacityfactors'
 csvname='awe_onshore_sw.csv'
-power_curve=pd.read_csv(inputpath + '\\power_curves\\AWE_500kw_softwing.csv')
+power_curve=pd.read_csv(inputpath / 'power_curves' / 'AWE_500kw_softwing.csv')
 
 coordinates=pd.read_csv('AWEcoordinates_onshore.csv')
 westlongitudes=coordinates['west_lon']
@@ -31,7 +32,7 @@ country=coordinates['Country']
 
 #%%
 # DATA COLLECTION API
-output_directory= inputpath + '\\netcdfs\\modellevel\\'
+output_directory= inputpath / 'netcdfs' / 'modellevel'
 import cdsapi
 c = cdsapi.Client()
 for wlon, elon, nlat, slat, fil in zip(westlongitudes, eastlongitudes, northlatitudes, southlatitudes, filename):
@@ -48,7 +49,7 @@ for wlon, elon, nlat, slat, fil in zip(westlongitudes, eastlongitudes, northlati
         'area': [nlat,wlon,slat,elon,],
         'grid': '0.25/0.25',
         'format': 'netcdf',
-    }, output_directory + fil )
+    }, output_directory / fil )
 
 #%% DATA PROCESSING, run after data collection is completed
 datetimeindex=pd.date_range("2013-01-01", periods= 52584, freq="H")
@@ -94,7 +95,7 @@ capfacavg=capfactable.mean(axis=0)
 
 ##export to CSV, make sure to adjust the name when running a new set of coordinates or a new technology
 
-capfactable.to_csv(outputpath + '\\ERA5_modellevel\\' + csvname)
+capfactable.to_csv(outputpath / 'ERA5_modellevel' / csvname)
 
 
 

--- a/ERA5_pressurelevel.py
+++ b/ERA5_pressurelevel.py
@@ -11,13 +11,15 @@ import pandas as pd
 import csv
 import datetime
 import numpy as np
+from pathlib import Path
 
-inputpath= 'YOUR DIRECTORY TO THIS FOLDER'
-outputpath= inputpath + '\\capacityfactors\\'
+
+inputpath= Path(__file__).parent
+outputpath= inputpath / 'capacityfactors'
 
 ##SELECT POWER CURVE
-power_curve=pd.read_csv(inputpath + '\\power_curves\\AWE_fixedwing1.csv')
-# power_curve=pd.read_csv(inputpath + '\\power_curves\\AWE_fixedwing2_offshore.csv')
+power_curve=pd.read_csv(inputpath / 'power_curves' / 'AWE_fixedwing1.csv')
+# power_curve=pd.read_csv(inputpath / 'power_curves' / 'AWE_fixedwing2_offshore.csv')
 
 #SELECT CORRECT SET OF COORDINATES
 coordinates=pd.read_csv('AWEcoordinates_shallow.csv') #shallow water AWE
@@ -40,7 +42,7 @@ location=location.tolist()
 country=coordinates['Country']
 
 #%% API REQUEST
-output_directory= inputpath + '\\netcdfs\\pressurelevel\\'
+output_directory= inputpath / 'netcdfs' / 'pressurelevel'
 
 import cdsapi
 c = cdsapi.Client()
@@ -84,7 +86,7 @@ for wlon, elon, nlat, slat, fil in zip(westlongitudes, eastlongitudes, northlati
         ],
         'area': [nlat,wlon,slat,elon,],
         'format': 'netcdf', 
-        }, output_directory + fil )
+        }, output_directory / fil )
     
 #%% DATA PROCESSING
 datetimeindex=pd.date_range("2013-01-01", periods= 52584, freq="H")
@@ -128,4 +130,4 @@ capfactable=capfactable.rename(columns={"Netherlands":"NLD","Germany":"DEU","Bel
 capfacavg=capfactable.mean(axis=0)
 
 ##export to CSV, make sure to adjust the name when running a new set of coordinates or a new technology
-capfactable.to_csv(outputpath + '\\ERA5_pressurelevel\\'+ csvname)
+capfactable.to_csv(outputpath / 'ERA5_pressurelevel' / csvname)

--- a/renewablesninja_API.py
+++ b/renewablesninja_API.py
@@ -11,9 +11,11 @@ import json
 import csv
 import numpy as np
 import time
+from pathlib import Path
 
-inputpath= 'YOUR DIRECTORY TO THIS FOLDER'
-outputpath= inputpath + '\\capacityfactors\\'
+
+inputpath= Path(__file__).parent
+outputpath= inputpath / 'capacityfactors'
 
 #SELECT COORDINATES
 coordinates=pd.read_csv('offshore_fixed_renninja_coordinates.csv')  #Fixed-Bottom offshore wind turbines
@@ -24,7 +26,7 @@ csvname='Offshorewind.csv'
 csvname='Floatingwind.csv'
 
 #POWER CURVE 15MW IEA TURBINE
-power_curve=pd.read_csv(inputpath + '\\power_curves\\IEA_15MW_offshore.csv')
+power_curve=pd.read_csv(inputpath / 'power_curves' / 'IEA_15MW_offshore.csv')
 
 daterange=pd.read_csv('daterange_renewablesninja.csv')
 startdate=daterange['date_from']
@@ -81,5 +83,5 @@ capfactable.columns=capfactable.columns.droplevel()
 capfactable=capfactable.rename(columns={"Denmark":"DNK","France":"FRA","Ireland":"IRL","Norway":"NOR","Sweden":"SWE","UK":"GBR"}) #floating only
 capfactable=capfactable.rename(columns={"Netherlands":"NLD","Germany":"DEU","Belgium":"BEL"}) #fixed offshore
 
-capfactable.to_csv(outputpath + csvname) 
+capfactable.to_csv(outputpath / csvname) 
 


### PR DESCRIPTION
Paths are concatenated as strings and containing "\\", which may work for windows, but not for all OSs.

To make the scripts easier to run on all machines, I propose to use pathlib.

Tested and works at least for the ERA5 scripts.

Please have a look and merge it if you are happy with it, @HiddeVostudelft.